### PR TITLE
Add link to qbittorrent-gluetun-port-update

### DIFF
--- a/setup/providers/private-internet-access.md
+++ b/setup/providers/private-internet-access.md
@@ -62,6 +62,10 @@ Once enabled, you will keep the same forwarded port for 60 days as long as you b
 
 [@jawilson](https://github.com/jawilson) developed a plugin to automagically update the forwarded port in Deluge: [**deluge-piaportplugin**](https://github.com/jawilson/deluge-piaportplugin)
 
+### qBittorrent
+
+[@TechnoSam](https://github.com/TechnoSam) developed a docker container to automagically update the forwarded port in qBittorent: [**qbittorent-gluetun-port-update**](https://hub.docker.com/r/technosam/qbittorrent-gluetun-port-update)
+
 ## Servers
 
 To see a list of servers available, [list the VPN servers with Gluetun](../servers.md#list-of-vpn-servers).


### PR DESCRIPTION
Thank you for maintaining this project! I really wanted to use qBittorrent with Gluetun, but I couldn't find any way to automatically update the forwarded port, so I made one myself. If you're using docker-compose, it's really easy to add this additional container to the deployment and keep the port up to date.

https://hub.docker.com/r/technosam/qbittorrent-gluetun-port-update

https://codeberg.org/TechnoSam/qbittorrent-gluetun-port-update

Hopefully this can be helpful to others who find themselves in my situation. Please let me know if there's any changes you'd like to see!