### PR TITLE
fix(protonvpn): add to wireguard list and remove from `VPN_PORT_FORWARDING_PROVIDER`

### DIFF
--- a/setup/options/port-forwarding.md
+++ b/setup/options/port-forwarding.md
@@ -7,6 +7,6 @@
 | Variable | Default | Choices | Description |
 | --- | --- | --- | --- |
 | `VPN_PORT_FORWARDING` | `off` | `off` or `on` | Enable custom port forwarding code for supported providers |
-| `VPN_PORT_FORWARDING_PROVIDER` | Current provider in use | `private internet access` or `protonvpn` | Choose the custom port forwarding code to use. This is useful when using the custom provider with Wireguard. For PIA, make sure you set `SERVER_NAMES=<server-name>`. |
+| `VPN_PORT_FORWARDING_PROVIDER` | Current provider in use | `private internet access` | Choose the custom port forwarding code to use. This is useful when using the custom provider with Wireguard. For PIA, make sure you set `SERVER_NAMES=<server-name>`. |
 | `VPN_PORT_FORWARDING_STATUS_FILE` | `/tmp/gluetun/forwarded_port` | Valid filepath | File path to use for writing the forwarded port obtained. |
 | `VPN_PORT_FORWARDING_LISTENING_PORT` | | Valid port number | Port redirection for the VPN server side port forwarded. |

--- a/setup/providers/protonvpn.md
+++ b/setup/providers/protonvpn.md
@@ -31,8 +31,6 @@ services:
       - SERVER_COUNTRIES=Netherlands
 ```
 
-💁 To use with Wireguard, download a configuration file from [account.proton.me/u/0/vpn/WireGuard](https://account.proton.me/u/0/vpn/WireGuard) and head to [the custom provider Wireguard section](custom.md#wireguard). Thanks to [@pvanryn](https://github.com/pvanryn) for pointing this out. Note however you cannot filter servers as easily as with OpenVPN since each server uses its own private key and/or peer address.
-
 ## Required environment variables
 
 - `VPN_SERVICE_PROVIDER=protonvpn`
@@ -66,11 +64,10 @@ services:
 
 ## VPN server port forwarding
 
-Requirements:
-
-- Add `+pmp` to your OpenVPN username (thanks to [@mortimr](https://github.com/qdm12/gluetun/issues/1760#issuecomment-1669518288))
 - `VPN_PORT_FORWARDING=on`
-- If you use **Wireguard** using the custom provider, set `VPN_PORT_FORWARDING_PROVIDER=protonvpn`
+ 
+### OpenVPN  only
+- Also add `+pmp` to your OpenVPN username (thanks to [@mortimr](https://github.com/qdm12/gluetun/issues/1760#issuecomment-1669518288))
 
 ## Multi hop regions
 

--- a/setup/providers/protonvpn.md
+++ b/setup/providers/protonvpn.md
@@ -66,6 +66,9 @@ services:
 
 - `VPN_PORT_FORWARDING=on` : this option is applicable for both OpenVPN and Wireguard.
 
+### OpenVPN  only
+- Also add `+pmp` to your OpenVPN username (thanks to [@mortimr](https://github.com/qdm12/gluetun/issues/1760#issuecomment-1669518288))
+
 ## Multi hop regions
 
 Simply set the `SERVER_HOSTNAMES` environment variable to a hostname corresponding to a multi hop region (see [Servers](#servers)).

--- a/setup/providers/protonvpn.md
+++ b/setup/providers/protonvpn.md
@@ -64,10 +64,7 @@ services:
 
 ## VPN server port forwarding
 
-- `VPN_PORT_FORWARDING=on`
- 
-### OpenVPN  only
-- Also add `+pmp` to your OpenVPN username (thanks to [@mortimr](https://github.com/qdm12/gluetun/issues/1760#issuecomment-1669518288))
+- `VPN_PORT_FORWARDING=on` : this option is applicable for both OpenVPN and Wireguard.
 
 ## Multi hop regions
 

--- a/setup/wireguard.md
+++ b/setup/wireguard.md
@@ -10,6 +10,7 @@ Gluetun supports Wireguard with native integration for the following providers:
 - [NordVPN](providers/nordvpn.md)
 - [Surfshark](providers/surfshark.md)
 - [Windscribe](providers/windscribe.md)
+- [ProtonVPN](providers/protonvpn.md)
 
 And you should refer to their respective page to set up easily Wireguard with them.
 

--- a/setup/wireguard.md
+++ b/setup/wireguard.md
@@ -8,9 +8,9 @@ Gluetun supports Wireguard with native integration for the following providers:
 - [Ivpn](providers/ivpn.md)
 - [Mullvad](providers/mullvad.md)
 - [NordVPN](providers/nordvpn.md)
+- [ProtonVPN](providers/protonvpn.md)
 - [Surfshark](providers/surfshark.md)
 - [Windscribe](providers/windscribe.md)
-- [ProtonVPN](providers/protonvpn.md)
 
 And you should refer to their respective page to set up easily Wireguard with them.
 


### PR DESCRIPTION
Update ProtonVPN instructions to include recent addition of Wireguard support in https://github.com/qdm12/gluetun/pull/2390

References to the custom provider have been removed as it is not necesary anymore.

This PR is mostly based on the comment of @TheRealBix (https://github.com/qdm12/gluetun/pull/2390#issuecomment-2266670716) in the upstream PR.

I tested those instructions in my environment and can confirm they are complete.
