### PR TITLE
Update docker_secrets.md to show all available options

### DIFF
--- a/setup/advanced/docker-secrets.md
+++ b/setup/advanced/docker-secrets.md
@@ -14,6 +14,10 @@ The following secrets can be used:
 - `openvpn_encrypted_key`
 - `openvpn_key_passphrase`
 - `openvpn_clientcrt`
+- `wireguard_conf`
+- `wireguard_private_key`
+- `wireguard_preshared_key`
+- `wireguard_addresses`
 - `httpproxy_user`
 - `httpproxy_password`
 - `shadowsocks_password`


### PR DESCRIPTION
The docker_secrets.md was missing some of the available secrets options, specifically some that I was needing. I figured I would help others who would like to include their wireguard private keys as secrets rather than in plain text.