### PR TITLE
Update podman tun.md `open /dev/net/tun: permission denied`

### DIFF
--- a/errors/tun.md
+++ b/errors/tun.md
@@ -50,7 +50,7 @@ Thanks to [@Vendetta1985](https://github.com/Vendetta1985), [source comment](htt
 ## `TUN device is not available: open /dev/net/tun: permission denied`
 
 This can happen with `podman`.
-The only way known is to run the container with `--privileged`.
+One known way is to run the container with `--privileged`, another solution that seems to work is to enable the SELinux flag `container_use_devices` by doing `sudo setsebool -P container_use_devices=1` (`-P` is for `persistant`).
 
 Thanks to [@OkanEsen](https://github.com/OkanEsen), [source comment](https://github.com/qdm12/gluetun/issues/700#issuecomment-1046259375)
 


### PR DESCRIPTION
TL/DR: I found another way to make use of `/dev/net/tun` without running in privileged mode.

---

Hi,
Upon tinkering with my jellyfin container (related to gluetun I promise) I found this [doc](https://jellyfin.org/docs/general/installation/container/#with-hardware-acceleration), while it didn't work in my case due to nvidia I found the idea quite clever and thought a variation of it would work for jellyfin + nvidia on podman.
After a lot of research (I'm missing some of the links to give proper credit, probably lost in the hundreds of browser tabs + history 😓), I fount that `container_use_devices` also exists and might be generic enough to enable my nvidia GPU to work with jellyfin.
It did, yay 🥳.

But after all that I wondered, would that work with gluetun? could i remove the `--privileged` from my compose file if said flag is properly setup ?
It also did !!
my current gluetun compose config
```yml
services:
    gluetun:
        cap_add:
            - NET_ADMIN
        container_name: gluetun
        environment:
            TZ: Europe/Paris
            VPN_SERVICE_PROVIDER: windscribe
            VPN_TYPE: wireguard
        image: docker.io/qmcgaw/gluetun:v3.39.1
        networks:
            shared:
                ipv4_address: 10.99.0.62
        restart: always
        secrets:
            - wireguard_private_key
            - wireguard_addresses
            - wireguard_preshared_key
        security_opt:
            - no-new-privileges=true
        sysctls:
            net.ipv6.conf.all.disable_ipv6: 1
```

---

All this lead me to this PR. I think it needs more testing, more people to try my findings before considering a valid fix/workaround.
there might even be another flag dedicated to net or tun devices, or a `security_opt` label that does it etc... (I'll look into it later, right now my bed is calling me 😴).

Edit: forgot to tell, running on almalinux 9.4 (latest ATM), using podman