### PR TITLE
Improve ProtonVPN documentation

### DIFF
--- a/setup/providers/protonvpn.md
+++ b/setup/providers/protonvpn.md
@@ -73,8 +73,6 @@ Requirements:
 - `VPN_PORT_FORWARDING=on`
 - For OpenVPN
   - Append `+pmp` to your OpenVPN username. For example, if your ProtonVPN username was `johndoe`, set `OPENVPN_USER` to `johndoe+pmp` (thanks to [@mortimr](https://github.com/qdm12/gluetun/issues/1760#issuecomment-1669518288)). ProtonVPN documentation on [port forwarding with OpenVPN](https://protonvpn.com/support/port-forwarding-manual-setup#openvpn)
-- For WireGuard
-  - Set `VPN_PORT_FORWARDING_PROVIDER=protonvpn`
 
 ## Multi hop regions
 

--- a/setup/providers/protonvpn.md
+++ b/setup/providers/protonvpn.md
@@ -47,9 +47,7 @@ services:
 ### Wireguard only
 
 - `VPN_TYPE=wireguard`
-- `WIREGUARD_PRIVATE_KEY` is your 32 byte key in base64 format.
-
-💁 To obtain the `WIREGUARD_PRIVATE_KEY` value, provision a configuration file from [account.proton.me/u/0/vpn/WireGuard](https://account.proton.me/u/0/vpn/WireGuard). The content of the WireGuard configuration file that ProtonVPN generates contains the `PrivateKey` value in the `[Interface]` section. Note that the private key value is the same for all ProtonVPN servers. All other values in the ProtonVPN WireGuard Configuration file should be ignored and not set in Gluetun environment variables. [ProtonVPN documentation on how to generate a WireGuard configuration file](https://protonvpn.com/support/wireguard-configurations/)
+- `WIREGUARD_PRIVATE_KEY` is your 32 byte key in base64 format. The private key can be obtained by [generating a Wireguard configuration file](https://account.proton.me/u/0/vpn/WireGuard) and copy the displayed `PrivateKey` value. Note this value is the same for all ProtonVPN servers. 💁 [Guide on how to generate a configuration file](https://protonvpn.com/support/wireguard-configurations/)
 
 ## Optional environment variables
 

--- a/setup/providers/protonvpn.md
+++ b/setup/providers/protonvpn.md
@@ -44,7 +44,7 @@ services:
 - `OPENVPN_USER` is your **OPENVPN specific** username. Find it at [account.proton.me/u/0/vpn/OpenVpnIKEv2](https://account.proton.me/u/0/vpn/OpenVpnIKEv2).
 - `OPENVPN_PASSWORD`
 
-### WireGuard only
+### Wireguard only
 
 - `VPN_TYPE=wireguard`
 - `WIREGUARD_PRIVATE_KEY` is your 32 byte key in base64 format.

--- a/setup/providers/protonvpn.md
+++ b/setup/providers/protonvpn.md
@@ -11,7 +11,7 @@ docker run -it --rm --cap-add=NET_ADMIN --device /dev/net/run \
 ```
 
 ```sh
-# Wireguard
+# WireGuard
 docker run -it --rm --cap-add=NET_ADMIN --device /dev/net/run \
 -e VPN_SERVICE_PROVIDER=protonvpn \
 -e VPN_TYPE=wireguard \
@@ -35,8 +35,6 @@ services:
       - SERVER_COUNTRIES=Netherlands
 ```
 
-💁 To use with Wireguard, download a configuration file from [account.proton.me/u/0/vpn/WireGuard](https://account.proton.me/u/0/vpn/WireGuard) and head to [the custom provider Wireguard section](custom.md#wireguard). Thanks to [@pvanryn](https://github.com/pvanryn) for pointing this out. Note however you cannot filter servers as easily as with OpenVPN since each server uses its own private key and/or peer address.
-
 ## Required environment variables
 
 - `VPN_SERVICE_PROVIDER=protonvpn`
@@ -46,10 +44,12 @@ services:
 - `OPENVPN_USER` is your **OPENVPN specific** username. Find it at [account.proton.me/u/0/vpn/OpenVpnIKEv2](https://account.proton.me/u/0/vpn/OpenVpnIKEv2).
 - `OPENVPN_PASSWORD`
 
-### Wireguard only
+### WireGuard only
 
 - `VPN_TYPE=wireguard`
-- `WIREGUARD_PRIVATE_KEY` is your 32 bytes key in base64 format. The private key can only be obtained by [generating a Wireguard configuration file](https://account.protonvpn.com/downloads). Generate a Wireguard configuration file, copy the displayed `PrivateKey` value and optionally download the configuration file. Note this value is the same for all ProtonVPN servers. 💁 [Guide on how to generate a configuration file](https://protonvpn.com/support/wireguard-configurations/)
+- `WIREGUARD_PRIVATE_KEY` is your 32 byte key in base64 format.
+
+💁 To obtain the `WIREGUARD_PRIVATE_KEY` value, provision a configuration file from [account.proton.me/u/0/vpn/WireGuard](https://account.proton.me/u/0/vpn/WireGuard). The content of the WireGuard configuration file that ProtonVPN generates contains the `PrivateKey` value in the `[Interface]` section. Note that the private key value is the same for all ProtonVPN servers. All other values in the ProtonVPN WireGuard Configuration file should be ignored and not set in Gluetun environment variables. [ProtonVPN documentation on how to generate a WireGuard configuration file](https://protonvpn.com/support/wireguard-configurations/)
 
 ## Optional environment variables
 
@@ -72,9 +72,12 @@ services:
 
 Requirements:
 
-- Add `+pmp` to your OpenVPN username (thanks to [@mortimr](https://github.com/qdm12/gluetun/issues/1760#issuecomment-1669518288))
 - `VPN_PORT_FORWARDING=on`
-- If you use **Wireguard** using the custom provider, set `VPN_PORT_FORWARDING_PROVIDER=protonvpn`
+- `PORT_FORWARD_ONLY=on` to tell Gluetun to only connect to servers that support port forwarding
+- For OpenVPN
+  - Append `+pmp` to your OpenVPN username. For example, if your ProtonVPN username was `johndoe`, set `OPENVPN_USER` to `johndoe+pmp` (thanks to [@mortimr](https://github.com/qdm12/gluetun/issues/1760#issuecomment-1669518288)). ProtonVPN documentation on [port forwarding with OpenVPN](https://protonvpn.com/support/port-forwarding-manual-setup#openvpn)
+- For WireGuard
+  - Set `VPN_PORT_FORWARDING_PROVIDER=protonvpn`
 
 ## Multi hop regions
 
@@ -86,7 +89,9 @@ For example setting `SERVER_HOSTNAMES=ch-us-01a.protonvpn.com` would set a multi
 
 Paid ProtonVPN subscribers can optionally use [Moderate NAT](https://protonvpn.com/support/moderate-nat/) on their connections.
 
-To do so, the OpenVPN username assigned by ProtonVPN should have `+nr` appended to the end of it.
+To do so with OpenVPN, append `+nr` to the ProtonVPN username. For example, if your ProtonVPN username was `johndoe`, set `OPENVPN_USER` to `johndoe+nr`.
+
+To do so with WireGuard, when provisioning a configuration file from [account.proton.me/u/0/vpn/WireGuard](https://account.proton.me/u/0/vpn/WireGuard), under `Select VPN options`, enable `Moderate NAT` before creating your configuration file containing your private key.
 
 ## Servers
 

--- a/setup/providers/protonvpn.md
+++ b/setup/providers/protonvpn.md
@@ -71,8 +71,7 @@ services:
 Requirements:
 
 - `VPN_PORT_FORWARDING=on`
-- For OpenVPN
-  - Append `+pmp` to your OpenVPN username. For example, if your ProtonVPN username was `johndoe`, set `OPENVPN_USER` to `johndoe+pmp` (thanks to [@mortimr](https://github.com/qdm12/gluetun/issues/1760#issuecomment-1669518288)). ProtonVPN documentation on [port forwarding with OpenVPN](https://protonvpn.com/support/port-forwarding-manual-setup#openvpn)
+- For OpenVPN only, append `+pmp` to your OpenVPN username (thanks to [@mortimr](https://github.com/qdm12/gluetun/issues/1760#issuecomment-1669518288)). If needed, see the [ProtonVPN OpenVPN port forwarding documentation](https://protonvpn.com/support/port-forwarding-manual-setup#openvpn).
 
 ## Multi hop regions
 

--- a/setup/providers/protonvpn.md
+++ b/setup/providers/protonvpn.md
@@ -83,9 +83,8 @@ For example setting `SERVER_HOSTNAMES=ch-us-01a.protonvpn.com` would set a multi
 
 Paid ProtonVPN subscribers can optionally use [Moderate NAT](https://protonvpn.com/support/moderate-nat/) on their connections.
 
-To do so with OpenVPN, append `+nr` to the ProtonVPN username. For example, if your ProtonVPN username was `johndoe`, set `OPENVPN_USER` to `johndoe+nr`.
-
-To do so with WireGuard, when provisioning a configuration file from [account.proton.me/u/0/vpn/WireGuard](https://account.proton.me/u/0/vpn/WireGuard), under `Select VPN options`, enable `Moderate NAT` before creating your configuration file containing your private key.
+- OpenVPN: append `+nr` to your ProtonVPN username
+- WireGuard: when [generating a configuration file](https://account.proton.me/u/0/vpn/WireGuard), under `Select VPN options`, enable `Moderate NAT`
 
 ## Servers
 

--- a/setup/providers/protonvpn.md
+++ b/setup/providers/protonvpn.md
@@ -71,7 +71,6 @@ services:
 Requirements:
 
 - `VPN_PORT_FORWARDING=on`
-- `PORT_FORWARD_ONLY=on` to tell Gluetun to only connect to servers that support port forwarding
 - For OpenVPN
   - Append `+pmp` to your OpenVPN username. For example, if your ProtonVPN username was `johndoe`, set `OPENVPN_USER` to `johndoe+pmp` (thanks to [@mortimr](https://github.com/qdm12/gluetun/issues/1760#issuecomment-1669518288)). ProtonVPN documentation on [port forwarding with OpenVPN](https://protonvpn.com/support/port-forwarding-manual-setup#openvpn)
 - For WireGuard

--- a/setup/providers/protonvpn.md
+++ b/setup/providers/protonvpn.md
@@ -11,7 +11,7 @@ docker run -it --rm --cap-add=NET_ADMIN --device /dev/net/run \
 ```
 
 ```sh
-# WireGuard
+# Wireguard
 docker run -it --rm --cap-add=NET_ADMIN --device /dev/net/run \
 -e VPN_SERVICE_PROVIDER=protonvpn \
 -e VPN_TYPE=wireguard \


### PR DESCRIPTION
* Remove the section that recommends users use follow the "custom provider" documentation. This section was accidentally left in, in https://github.com/qdm12/gluetun/pull/2390 but should have been removed (as @heronimoo [points out][1]). Removing this section will prevent users from following the "custom provider" instructions and incorrectly setting values like `WIREGUARD_ENDPOINT_IP`, `WIREGUARD_ENDPOINT_PORT`, `WIREGUARD_PUBLIC_KEY` and `WIREGUARD_ADDRESSES`. If the user sets `WIREGUARD_ENDPOINT_PORT` it triggers the ["endpoint port is set" error][2]
* Remove the note about each WireGuard server using it's own private key (as later in the page it states that the private key is the same for all servers)
* Expand the documentation about the `WIREGUARD_PRIVATE_KEY` value to state explicitly to ignore all the unused values in the ProtonVPN generated configuration file. This also changes the link from the ProtonVPN downloads page to the ProtonVPN page for generating WireGuard configs.
* Reorganize the VPN server port forwarding section to clarify which settings apply to OpenVPN and which apply to WireGuard.
* Add the `PORT_FORWARD_ONLY` setting to the VPN server port forwarding section
* Add examples to clarify the OpenVPN username appending trick for port forwarding and moderate NAT.
* Fix capitalization of WireGuard

[1]: https://github.com/qdm12/gluetun/pull/2390#issuecomment-2333917291
[2]: https://github.com/qdm12/gluetun/blob/68ddbfc0fed316f2e22c3b979b2186522a194da1/internal/configuration/settings/wireguardselection.go#L59-L64