### PR TITLE
add example for proton vpn port forwarding setup

### DIFF
--- a/setup/advanced/scripts/qbittorrent-port-updater.sh
+++ b/setup/advanced/scripts/qbittorrent-port-updater.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+
+LISTEN_PORT="$1"
+QBIT_PROTOCOL="${QBIT_PROTOCOL:-http}"
+QBIT_HOST="${QBIT_HOST:-127.0.0.1}"
+QBIT_PORT="${QBIT_PORT:-8080}"
+
+# add curl if not already installed
+apk info | grep -q ^curl || apk add curl
+
+# syntax specific to sh
+for run in $(seq 1 10)
+do
+  echo "Try $run/10 to set port to $LISTEN_PORT"
+  curl -ks --data 'json={"listen_port": "'"$LISTEN_PORT"'"}' ${QBIT_PROTOCOL}://${QBIT_HOST}:${QBIT_PORT}/api/v2/app/setPreferences
+  if [ $? -eq 0 ]; then
+      echo "Port $LISTEN_PORT set successfully"
+      break
+  fi
+  echo "Failed to set port, retrying in 5 seconds"
+  sleep 5
+done

--- a/setup/advanced/vpn-port-forwarding.md
+++ b/setup/advanced/vpn-port-forwarding.md
@@ -34,6 +34,15 @@ Notes:
 - one can bind mount a shell script in Gluetun and execute it with for example `VPN_PORT_FORWARDING_UP_COMMAND=/bin/sh -c /gluetun/myscript.sh` - 💁  feel free to propose a pull request to add commonly used shell scripts for port forwarding!
 - the output of the command is written to the port forwarding logger within Gluetun
 
+### qBittorrent Example
+
+See [qbittorrent-port-updater.sh](scripts/qbittorrent-port-updater.sh) for an example of how this can be done. Add a bind mount to this script and then refert to it: `VPN_PORT_FORWARDING_UP_COMMAND=/bin/sh -c "/tmp/qbit-port-updater.sh {{PORTS}}"`
+
+Notes:
+
+- In order to get the call working make sure port qBittorrent is listening on is open. For example `- 8080:8080` to the ports definition. Without this calls do not go through.
+- Add `127.0.0.1/32` to bypass authentication settings for qBittorrent.
+
 ## Allow a forwarded port through the firewall
 
 For non-native integrations where you have a designated forwarded port from your VPN provider, you can allow it by adding it to the environment variable `FIREWALL_VPN_INPUT_PORTS`.

--- a/setup/providers/protonvpn.md
+++ b/setup/providers/protonvpn.md
@@ -35,7 +35,7 @@ services:
       - SERVER_COUNTRIES=Netherlands
 ```
 
-💁 To use with Wireguard, download a configuration file from [account.proton.me/u/0/vpn/WireGuard](https://account.proton.me/u/0/vpn/WireGuard) and head to [the custom provider Wireguard section](custom.md#wireguard). Thanks to [@pvanryn](https://github.com/pvanryn) for pointing this out. Note however you cannot filter servers as easily as with OpenVPN since each server uses its own private key and/or peer address.
+💁 To use with Wireguard, download a configuration file from [account.proton.me/u/0/vpn/WireGuard](https://account.proton.me/u/0/vpn/WireGuard) and set the `WIREGUARD_PRIVATE_KEY`. You can do a [the custom provider Wireguard section](custom.md#wireguard) to pick a specific server. Thanks to [@pvanryn](https://github.com/pvanryn) for pointing this out.
 
 ## Required environment variables
 
@@ -75,6 +75,7 @@ Requirements:
 - Add `+pmp` to your OpenVPN username (thanks to [@mortimr](https://github.com/qdm12/gluetun/issues/1760#issuecomment-1669518288))
 - `VPN_PORT_FORWARDING=on`
 - If you use **Wireguard** using the custom provider, set `VPN_PORT_FORWARDING_PROVIDER=protonvpn`
+- See [custom port forwarding updown command](advanced/vpn-port-forwarding.md#custom-port-forwarding-updown-command) for examples of how to automate this.
 
 ## Multi hop regions
 


### PR DESCRIPTION
Adding a sample script that shows how to update listening port for qbittorrent. Script uses curl which its installing at run time. If it's possible to add curl to the base image that would be ideal. I can send a PR but was not sure if we are trying to minimize the size of the base image.

Also removed some verbiage around how filtering for proton vpn wireguard servers was not ideal. I saw conflicting statements in the readme where one section mentioned private key's were different and another said they were the same. From my usage I did not need to do a custom provider setup and just had to set the private key and the p2p filtering option. I could get it working with the following options.

```
VPN_SERVICE_PROVIDER=protonvpn
WIREGUARD_PRIVATE_KEY=xxxxx
SERVER_COUNTRIES=Netherlands,Switzerland
VPN_PORT_FORWARDING=on
PORT_FORWARD_ONLY=on
VPN_PORT_FORWARDING_UP_COMMAND=/bin/sh -c "/tmp/qbit-port-updater.sh {{PORTS}}"
```

So i assumed those statements were no longer accurate? 