### PR TITLE
feat(windscribe): static ip permanent port forwarding instructions

### DIFF
--- a/setup/providers/windscribe.md
+++ b/setup/providers/windscribe.md
@@ -72,7 +72,8 @@ services:
 
 #### Permanent Port Forwarding (Static IP)
 1. You will need to follow the [custom provider guide](https://github.com/qdm12/gluetun-wiki/blob/main/setup/providers/custom.md).
-2. It's reccomended that you use the configuration file that Windscribe gives you for [OpenVPN](https://windscribe.com/getconfig/openvpn) or [WireGuard](https://windscribe.com/getconfig/wireguard).
+2. In your container configuration, set `FIREWALL_VPN_INPUT_PORTS` to the port you have been assigned, for example: `FIREWALL_VPN_INPUT_PORTS=8099`
+3. It's reccomended that you use the configuration file that Windscribe gives you for [OpenVPN](https://windscribe.com/getconfig/openvpn) or [WireGuard](https://windscribe.com/getconfig/wireguard).
 
 ## Servers
 

--- a/setup/providers/windscribe.md
+++ b/setup/providers/windscribe.md
@@ -66,8 +66,13 @@ services:
 
 ### VPN server port forwarding
 
+#### Ephemeral Port Forwarding
 1. Follow the [Windscribe instructions](https://windscribe.com/support/article/37/what-is-ephemeral-port-forwarding-and-how-to-use-it)
 1. In your container configuration, set `FIREWALL_VPN_INPUT_PORTS` to the port you have been assigned, for example: `FIREWALL_VPN_INPUT_PORTS=8099`
+
+#### Permanent Port Forwarding (Static IP)
+1. You will need to follow the [custom provider guide](https://github.com/qdm12/gluetun-wiki/blob/main/setup/providers/custom.md).
+2. It's reccomended that you use the configuration file that Windscribe gives you for [OpenVPN](https://windscribe.com/getconfig/openvpn) or [WireGuard](https://windscribe.com/getconfig/wireguard).
 
 ## Servers
 

--- a/setup/providers/windscribe.md
+++ b/setup/providers/windscribe.md
@@ -73,9 +73,8 @@ services:
 
 #### Permanent port forwarding (static IP)
 
-1. You will need to follow the [custom provider guide](https://github.com/qdm12/gluetun-wiki/blob/main/setup/providers/custom.md).
-2. In your container configuration, set `FIREWALL_VPN_INPUT_PORTS` to the port you have been assigned, for example: `FIREWALL_VPN_INPUT_PORTS=8099`
-3. It's reccomended that you use the configuration file that Windscribe gives you for [OpenVPN](https://windscribe.com/getconfig/openvpn) or [WireGuard](https://windscribe.com/getconfig/wireguard).
+1. Follow the [custom provider setup instructions](https://github.com/qdm12/gluetun-wiki/blob/main/setup/providers/custom.md), using the [openvpn](https://windscribe.com/getconfig/openvpn) or [wireguard](https://windscribe.com/getconfig/wireguard) configuration file that Windscribe provides for static ips.
+1. In your container configuration, set `FIREWALL_VPN_INPUT_PORTS` to the port you have been assigned, for example: `FIREWALL_VPN_INPUT_PORTS=8099`
 
 ## Servers
 

--- a/setup/providers/windscribe.md
+++ b/setup/providers/windscribe.md
@@ -71,7 +71,8 @@ services:
 1. Follow the [Windscribe instructions](https://windscribe.com/support/article/37/what-is-ephemeral-port-forwarding-and-how-to-use-it)
 1. In your container configuration, set `FIREWALL_VPN_INPUT_PORTS` to the port you have been assigned, for example: `FIREWALL_VPN_INPUT_PORTS=8099`
 
-#### Permanent Port Forwarding (Static IP)
+#### Permanent port forwarding (static IP)
+
 1. You will need to follow the [custom provider guide](https://github.com/qdm12/gluetun-wiki/blob/main/setup/providers/custom.md).
 2. In your container configuration, set `FIREWALL_VPN_INPUT_PORTS` to the port you have been assigned, for example: `FIREWALL_VPN_INPUT_PORTS=8099`
 3. It's reccomended that you use the configuration file that Windscribe gives you for [OpenVPN](https://windscribe.com/getconfig/openvpn) or [WireGuard](https://windscribe.com/getconfig/wireguard).

--- a/setup/providers/windscribe.md
+++ b/setup/providers/windscribe.md
@@ -66,7 +66,8 @@ services:
 
 ### VPN server port forwarding
 
-#### Ephemeral Port Forwarding
+#### Ephemeral port forwarding
+
 1. Follow the [Windscribe instructions](https://windscribe.com/support/article/37/what-is-ephemeral-port-forwarding-and-how-to-use-it)
 1. In your container configuration, set `FIREWALL_VPN_INPUT_PORTS` to the port you have been assigned, for example: `FIREWALL_VPN_INPUT_PORTS=8099`
 


### PR DESCRIPTION
The typical instructions you would follow otherwise don't work, since you need to connect to a specified endpoint and such.

This method works for Windscribe's static IP / Permanent Port Forwarding service.