### PR TITLE
Add qBittorrent VPN_PORT_FORWARDING_UP_COMMAND example with authentication.

### DIFF
--- a/setup/advanced/vpn-port-forwarding.md
+++ b/setup/advanced/vpn-port-forwarding.md
@@ -79,7 +79,7 @@ done
 set -e
 
 if [ "$response" != "Ok." ]; then
-    echo "Unable to log in to to qBittorrent."
+    echo "Unable to log in to qBittorrent."
     rm -f /tmp/cookies.txt
 
     exit 1

--- a/setup/advanced/vpn-port-forwarding.md
+++ b/setup/advanced/vpn-port-forwarding.md
@@ -38,6 +38,7 @@ Notes:
 
 #### with authentication
 
+##### compose.yml
 ```yaml
 services:
   pf-gluetun:
@@ -53,6 +54,7 @@ services:
     ...
 ```
 
+##### update-port.sh
 ```sh
 #!/bin/sh
 set -e

--- a/setup/advanced/vpn-port-forwarding.md
+++ b/setup/advanced/vpn-port-forwarding.md
@@ -61,7 +61,7 @@ set -e
 
 port="$1"
 
-echo "Logging in to QBittorrent as $QBIT_USERNAME..."
+echo "Logging in to qBittorrent as $QBIT_USERNAME..."
 
 wget --quiet --save-cookies=/tmp/cookies.txt --keep-session-cookies \
      --post-data="username=$QBIT_USERNAME&password=$QBIT_PASSWORD" \
@@ -87,7 +87,7 @@ if grep -q "403 Forbidden" /tmp/set_preferences_response.txt; then
   exit 1
 fi
 
-echo "QBittorrent port updated successfully."
+echo "qBittorrent port updated successfully."
 ```
 
 #### without authentication

--- a/setup/advanced/vpn-port-forwarding.md
+++ b/setup/advanced/vpn-port-forwarding.md
@@ -76,7 +76,7 @@ if [ "$login_response" != "Ok." ]; then
 fi
 
 echo "Login successful. Session cookie saved."
-echo "Updating QBittorrent port to $port..."
+echo "Updating qBittorrent port to $port..."
 
 wget --quiet --load-cookies=/tmp/cookies.txt \
      --post-data="json={\"listen_port\": $port}" \

--- a/setup/advanced/vpn-port-forwarding.md
+++ b/setup/advanced/vpn-port-forwarding.md
@@ -37,9 +37,8 @@ Notes:
 ### qBittorrent examples
 
 #### with authentication
-
-##### compose.yml
 ```yaml
+# compose.yml
 services:
   pf-gluetun:
     image: qmcgaw/gluetun
@@ -53,10 +52,9 @@ services:
       - ./gluetun/update-port.sh:/gluetun/update-port.sh
     ...
 ```
-
-##### update-port.sh
 ```sh
 #!/bin/sh
+# update-port.sh
 set -e
 
 port="$1"

--- a/setup/advanced/vpn-port-forwarding.md
+++ b/setup/advanced/vpn-port-forwarding.md
@@ -34,7 +34,61 @@ Notes:
 - one can bind mount a shell script in Gluetun and execute it with for example `VPN_PORT_FORWARDING_UP_COMMAND=/bin/sh -c /gluetun/myscript.sh` - 💁  feel free to propose a pull request to add commonly used shell scripts for port forwarding!
 - the output of the command is written to the port forwarding logger within Gluetun
 
-### qBittorrent example
+### qBittorrent examples
+
+#### with authentication
+
+```yaml
+services:
+  pf-gluetun:
+    image: qmcgaw/gluetun
+    environment:
+      QBIT_ADDRESS: http://localhost:8080
+      QBIT_USERNAME: yourusername
+      QBIT_PASSWORD: yourpassword
+      VPN_PORT_FORWARDING_UP_COMMAND: /bin/sh -c 'sh /gluetun/update-port.sh "{{PORTS}}"'
+      ...
+    volumes:
+      - ./gluetun/update-port.sh:/gluetun/update-port.sh
+    ...
+```
+
+```sh
+#!/bin/sh
+set -e
+
+port="$1"
+
+echo "Logging in to QBittorrent as $QBIT_USERNAME..."
+
+wget --quiet --save-cookies=/tmp/cookies.txt --keep-session-cookies \
+     --post-data="username=$QBIT_USERNAME&password=$QBIT_PASSWORD" \
+     --header="Referer: $QBIT_ADDRESS" \
+     "$QBIT_ADDRESS/api/v2/auth/login" -O /tmp/login_response.txt
+
+login_response=$(cat /tmp/login_response.txt)
+
+if [ "$login_response" != "Ok." ]; then
+  echo "Error: Login failed. Response: $login_response"
+  exit 1
+fi
+
+echo "Login successful. Session cookie saved."
+echo "Updating QBittorrent port to $port..."
+
+wget --quiet --load-cookies=/tmp/cookies.txt \
+     --post-data="json={\"listen_port\": $port}" \
+     "$QBIT_ADDRESS/api/v2/app/setPreferences" -O /tmp/set_preferences_response.txt
+
+if grep -q "403 Forbidden" /tmp/set_preferences_response.txt; then
+  echo "Error: Setting port failed. Unauthorized (403 Forbidden)."
+  exit 1
+fi
+
+echo "QBittorrent port updated successfully."
+```
+
+#### without authentication
 
 `VPN_PORT_FORWARDING_UP_COMMAND=/bin/sh -c 'wget -O- --retry-connrefused --post-data "json={\"listen_port\":{{PORTS}}}" http://127.0.0.1:8080/api/v2/app/setPreferences 2>&1'`
 

--- a/setup/advanced/vpn-port-forwarding.md
+++ b/setup/advanced/vpn-port-forwarding.md
@@ -55,8 +55,6 @@ services:
 ```sh
 #!/bin/sh
 # update-port.sh
-set -e
-
 port="$1"
 retries="${UPDATE_PORT_RETRIES:-5}"
 interval="${UPDATE_PORT_RETRY_INTERVAL:-10}"
@@ -77,6 +75,8 @@ for i in $(seq 1 "$retries"); do
 
   sleep "$interval"
 done
+
+set -e
 
 if [ "$response" != "Ok." ]; then
     echo "Unable to log in to to qBittorrent."


### PR DESCRIPTION
I'd rather not disable authentication in qBittorrent to get the new `VPN_PORT_FORWARDING_UP_COMMAND` option working, I'm sure I'm not the only one. So, I believe this will be a useful example to many users.

It'd be messy to authenticate and update the port directly in the compose, so I use a script that's mounted as a volume.