### PR TITLE
Update qBittorrent example to add a DOWN_COMMAND

### DIFF
--- a/setup/advanced/vpn-port-forwarding.md
+++ b/setup/advanced/vpn-port-forwarding.md
@@ -37,8 +37,10 @@ Notes:
 ### qBittorrent example
 
 `VPN_PORT_FORWARDING_UP_COMMAND=/bin/sh -c 'wget -O- --retry-connrefused --post-data "json={\"listen_port\":{{PORTS}}}" http://127.0.0.1:8080/api/v2/app/setPreferences 2>&1'`
+`VPN_PORT_FORWARDING_DOWN_COMMAND=/bin/sh -c 'wget -O- --retry-connrefused --post-data "json={\"listen_port\":123}" http://127.0.0.1:8080/api/v2/app/setPreferences 2>&1'`
 
 For this to work, the qBittorrent web UI server must be enabled and listening on port `8080` and the Web UI "Bypass authentication for clients on localhost" must be ticked (json key `bypass_local_auth`) so Gluetun can reach qBittorrent without authentication.
+Due to a bug in qBittorrent, for port forwarding to be reestablished after a disconnect, the port needs to be re-set. This can be achieved automatically using the DOWN_COMMAND above.
 
 Thanks to [@Marsu31](https://github.com/Marsu31)
 


### PR DESCRIPTION
For me, adding this down command addressed my issue with qBittorrent failing to reconnect after the VPN dies, which others seem to have experienced as well:

https://github.com/qdm12/gluetun/issues/1407
https://github.com/qdm12/gluetun/issues/2202
https://github.com/qdm12/gluetun/issues/2515

This also seems more efficient than using another container to do the same like in https://github.com/qdm12/gluetun/issues/1407#issuecomment-1461582887

I've only had my port forwarding die once in the week since I set this up, but it fixed it when I previously had to restart the container.