### PR TITLE
Simplify IPv6 setup

### DIFF
--- a/setup/advanced/ipv6.md
+++ b/setup/advanced/ipv6.md
@@ -13,13 +13,13 @@ If you find something suspect related to IPv6, please create an issue on this re
     ```
 
     Should show something.
-2. Modify your default network in your `docker-compose.yml` file as shown below, or alternatively create a new network that you add gluetun to:
+2. Modify your default network and add the `sysctls` section in your `docker-compose.yml` file as shown below, or alternatively create a new network that you add gluetun to:
 ```yaml
 services:
   gluetun:
-    image: qmcgaw/gluetun
-    container_name: gluetun
-    # ... the rest of gluetun's configuration options 
+    # ...
+    sysctls:
+      - net.ipv6.conf.all.disable_ipv6=0
 
 networks:
   default:

--- a/setup/advanced/ipv6.md
+++ b/setup/advanced/ipv6.md
@@ -13,40 +13,29 @@ If you find something suspect related to IPv6, please create an issue on this re
     ```
 
     Should show something.
-1. On your Docker host, edit and create if needed `/etc/docker/daemon.json` with the following JSON key-value pairs:
+2. Modify your default network in your `docker-compose.yml` file as shown below, or alternatively create a new network that you add gluetun to:
+```yaml
+services:
+  gluetun:
+    image: qmcgaw/gluetun
+    container_name: gluetun
+    # ... the rest of gluetun's configuration options 
 
-    ```json
-    {
-      "ipv6": true,
-      "fixed-cidr-v6": "2001:db8:1::/64",
-      "experimental": true,
-      "ip6tables": true
-    }
-    ```
+networks:
+  default:
+    enable_ipv6: true
+    driver: bridge
+```
+3. Depending on the VPN protocol used:
+- OpenVPN: the IPv6 server address and configuration will automatically be picked up if IPv6 support is detected
+- Wireguard: modify the `WIREGUARD_ADDRESSES` value to have both an IPv4 and IPv6 address, separated by commas. Note if you only set an IPv6 Wireguard address, no IPv4 traffic will be allowed through which will have undesired effects.
 
-    ⚠️ Ensure to change the [documented address `2001:db8:1::/64`](https://en.wikipedia.org/wiki/Reserved_IP_addresses#IPv6) with a valid IPv6 network. The default IPv4 pools are from the private address range, the IPv6 equivalent would be ULA networks.
-
-    [Reference: Docker documentation on IPv6](https://docs.docker.com/config/daemon/ipv6/#use-ipv6-for-the-default-bridge-network)
-1. Restart the Docker daemon to reload its JSON configuration. Most Linux distributions use `sudo systemctl restart docker` to do this.
-1. Edit your Gluetun `docker-compose.yml` and add the `sysctls` section:
-
-    ```yaml
-    services:
-      gluetun:
-        # ...
-        sysctls:
-          - net.ipv6.conf.all.disable_ipv6=0
-    ```
-
-1. Depending on the VPN protocol used:
-    - OpenVPN: the IPv6 server address and configuration will automatically be picked up if IPv6 support is detected
-    - Wireguard: modify the `WIREGUARD_ADDRESSES` value to have both an IPv4 and IPv6 address. Note if you only set an IPv6 Wireguard address, all IPv4 traffic won't go through which is undesirable.
-1. Test your setup:
+4. Test your setup:
     1. Launch your docker-compose stack
-    1. Run:
+    1. Run the following command:
 
         ```sh
-        sudo docker run --rm --network=container:gluetun alpine:3.22 sh -c "apk add curl && curl -6 --silent https://ipv6.ipleak.net/json/"
+        sudo docker exec -t gluetun sh -c "apk add curl && curl -6 --silent https://ipv6.ipleak.net/json/"
         ```
 
-        And this should show the IPv6 address of the VPN server.
+        which should show the IPv6 address of the VPN server.


### PR DESCRIPTION
This is a simpler way to achieve IPv6 connection within gluetun, without needing to modify the daemon file.

Notes:

- ip6tables are enabled by default, according to [documentation](https://docs.docker.com/engine/daemon/ipv6/#use-ipv6-for-the-default-bridge-network)
- `enable_ipv6` in compose will automatically assign a local IPv6 address for internal use in the container, doesn't need to be specified
- `sysctls` modification is not necessary on my system, although I'm not sure about why it was added in the first place it may as well stay. Might be necessary on some systems, I'm not sure how it is assigned (does it maybe inherit from the host?)

I have tested `curl`ing ipleak.net over Wireguard and only saw the VPN address from my very short testing. I can't speak for any technical aspects of how gluetun binds to different addresses but this seems to be equivalent to what was documented previously, but quite a bit simpler.

I could maybe add some notes on provider support, but I'm not sure exactly how it works. I assume if the Wireguard config has the IPv6 address in WIREGUARD_ADDRESSES, it should be plug and play, but as of now ProtonVPN which I use do not include the IPv6. I have however gotten Proton to work using the custom provider and manually adding their IPv6 address. 
edit: after configuring some more it seems I can override the WIREGUARD_ADDRESSES and use this with the protonvpn provider, by just also adding proton's wireguard ipv6 address (which is availible online some places, but doesn't seem to be included in their configs by default). I could document this as well if you're interested (generically, not specific to proton)