### PR TITLE
chore(setup/providers/privatevpn): clarify Openvpn options

### DIFF
--- a/setup/providers/privatevpn.md
+++ b/setup/providers/privatevpn.md
@@ -32,8 +32,8 @@ services:
 ## Required environment variables
 
 - `VPN_SERVICE_PROVIDER=privatevpn`
-- `OPENVPN_USER`
-- `OPENVPN_PASSWORD`
+- `OPENVPN_USER`: Your PrivateVPN account login, not the "Proxy login" found on its Control Panel
+- `OPENVPN_PASSWORD`: Your PrivateVPN account password
 
 ## Optional environment variables
 


### PR DESCRIPTION
Clarify the purpose of OPENVPN_USER and OPENVPN_PASSWORD. Some people may mix-up the proxy login found on PrivateVPN control panel by a OpenVPN username, as I did. 

I got confused because using a different username for VPN login and account login is usual practice and the "Proxy login" is just above the "Generate wireguard config", what made me mistakenly take it for VPN login.