### PR TITLE
fix: Fix qBittorrent example on VPN_PORT_FORWARDING_DOWN_COMMAND

### DIFF
--- a/setup/advanced/vpn-port-forwarding.md
+++ b/setup/advanced/vpn-port-forwarding.md
@@ -42,7 +42,7 @@ Notes:
 ### qBittorrent example
 
 `VPN_PORT_FORWARDING_UP_COMMAND=/bin/sh -c 'wget -O- --retry-connrefused --post-data "json={\"listen_port\":{{PORT}},\"current_network_interface\":\"{{VPN_INTERFACE}}\",\"random_port\":false,\"upnp\":false}" http://127.0.0.1:8080/api/v2/app/setPreferences 2>&1'`
-`VPN_PORT_FORWARDING_DOWN_COMMAND=/bin/sh -c 'wget -O- --retry-connrefused --post-data "json={\"listen_port\":0,\"current_network_interface\":\"lo"}" http://127.0.0.1:8080/api/v2/app/setPreferences 2>&1'`
+`VPN_PORT_FORWARDING_DOWN_COMMAND=/bin/sh -c 'wget -O- --retry-connrefused --post-data "json={\"listen_port\":0,\"current_network_interface\":\"lo\"}" http://127.0.0.1:8080/api/v2/app/setPreferences 2>&1'`
 
 For this to work, the qBittorrent web UI server must be enabled and listening on port `8080` and the Web UI "Bypass authentication for clients on localhost" must be ticked (json key `bypass_local_auth`) so Gluetun can reach qBittorrent without authentication.
 Due to a bug in qBittorrent, for port forwarding to be reestablished after a disconnect, the port needs to be re-set. This can be achieved automatically using the DOWN_COMMAND above.


### PR DESCRIPTION
Was missing a quote escape