### PR TITLE
fix(setup/options/others): update PUBLICIP_API default and choices

### DIFF
--- a/setup/options/others.md
+++ b/setup/options/others.md
@@ -11,7 +11,7 @@
 | `PUID` | `1000` | | User ID to run as non root and for ownership of files written |
 | `PGID` | `1000` | | Group ID to run as non root and for ownership of files written |
 | `PUBLICIP_ENABLED` | `true` | `true`, `false` | Check for public IP address information on VPN connection |
-| `PUBLICIP_API` | `ipinfo` | `ipinfo`, `ip2location`, `cloudflare` or custom URL | Public IP echo service API to use or an echoip URL in the form `echoip#https://xyz` |
+| `PUBLICIP_API` | `ipinfo,ifconfigco,ip2location,cloudflare` | `ipinfo`, `ifconfigco`, `ip2location`, `cloudflare` or custom URL | Public IP echo service API to use or an echoip URL in the form `echoip#https://xyz` |
 | `PUBLICIP_API_TOKEN` | | | Optional API token for the public IP echo service to increase rate limiting |
 | `PUBLICIP_FILE` | `/tmp/gluetun/ip` | Any filepath | Filepath to store the public IP address assigned. This will be removed in the `v4` program, instead you might want to use the [control server](../advanced/control-server.md) |
 | `VERSION_INFORMATION` | `on` | `on`, `off` | Logs a message indicating if a newer version is available once the VPN is connected |


### PR DESCRIPTION
In Gluetun v3.41 PUBLICIP_API default value and allowed values changed.