### PR TITLE
PureVPN provider revamp docs

### DIFF
--- a/setup/providers/purevpn.md
+++ b/setup/providers/purevpn.md
@@ -37,9 +37,51 @@ services:
 
 - `SERVER_COUNTRIES`: Comma separated list of countries
 - `SERVER_CITIES`: Comma separated list of cities
-- `SERVER_TYPES`: Comma separated list of server type tags. For PureVPN, this can include values such as `p2p`, `obfuscation`, `quantumresistant`, and `portforwarding`. Servers must match all values set.
-- `SERVER_CATEGORIES`: Comma separated list of server category tags. Servers must match all values set.
+- `SERVER_TYPES`: Comma separated list of PureVPN type filters. Servers must match all values set.
+  - Allowed values:
+    - `regular`: non-`portforwarding`, non-`quantumresistant`, non-`obfuscation`, non-`p2p`
+    - `portforwarding`
+    - `quantumresistant`
+    - `obfuscation`
+    - `p2p`
+  - Accepted aliases:
+    - `portforward`, `pf` -> `portforwarding`
+    - `quantum`, `qr` -> `quantumresistant`
+    - `obfuscated`, `obf` -> `obfuscation`
+- `SERVER_CATEGORIES`: Comma separated list of server categories from the PureVPN inventory feed. Servers must match all values set.
+  - In current PureVPN data, the category in use is `p2p`.
 - `SERVER_HOSTNAMES`: Comma separated list of server hostnames. Beware this is the narrowest filter, so if you set this to a single hostname and this hostname disappears from the Gluetun servers data due to an update, your container will no longer work until this filter is changed. I would suggest avoiding it unless you know this reliability risk.
+
+## Filtering examples
+
+### By type
+
+```sh
+# Any obfuscated server
+SERVER_TYPES=obfuscation
+
+# Must be both p2p and quantum resistant
+SERVER_TYPES=p2p,quantumresistant
+
+# Alias example, equivalent to SERVER_TYPES=portforwarding,obfuscation
+SERVER_TYPES=pf,obf
+```
+
+### By category
+
+```sh
+# Current PureVPN category usage
+SERVER_CATEGORIES=p2p
+```
+
+### Combined with location
+
+```sh
+# In US/Canada, city match, and must be p2p + quantum resistant
+SERVER_COUNTRIES=United States,Canada
+SERVER_CITIES=New York,Toronto
+SERVER_TYPES=p2p,quantumresistant
+```
 
 ## Servers
 

--- a/setup/providers/purevpn.md
+++ b/setup/providers/purevpn.md
@@ -36,8 +36,9 @@ services:
 ## Optional environment variables
 
 - `SERVER_COUNTRIES`: Comma separated list of countries
-- `SERVER_REGIONS`: Comma separated list of regions
 - `SERVER_CITIES`: Comma separated list of cities
+- `SERVER_TYPES`: Comma separated list of server type tags. For PureVPN, this can include values such as `p2p`, `obfuscation`, `quantumresistant`, and `portforwarding`. Servers must match all values set.
+- `SERVER_CATEGORIES`: Comma separated list of server category tags. Servers must match all values set.
 - `SERVER_HOSTNAMES`: Comma separated list of server hostnames. Beware this is the narrowest filter, so if you set this to a single hostname and this hostname disappears from the Gluetun servers data due to an update, your container will no longer work until this filter is changed. I would suggest avoiding it unless you know this reliability risk.
 
 ## Servers


### PR DESCRIPTION
## Description

PureVPN provider revamp documentation update:
- remove `SERVER_REGIONS` for PureVPN
- document `SERVER_CITIES` as the location-specific selector
- document `SERVER_TYPES` and `SERVER_CATEGORIES` as comma-delimited tag filters (AND matching)

## Linked issue

- qdm12/gluetun#3148
- Companion code PR: qdm12/gluetun#3165
