### PR TITLE
feat(setup/options/firewall): `FIREWALL_OUTBOUND_SUBNETS` can be affected by dns rebinding protection

### DIFF
--- a/setup/options/dns.md
+++ b/setup/options/dns.md
@@ -12,7 +12,7 @@
 | `DNS_UPSTREAM_IPV6` | `off` | `on`, `off` | DNS IPv6 resolution |
 | `DNS_BLOCK_IPS` | | Any valid IP address | Comma separated list of IP addresses to not resolve public domains to. |
 | `DNS_BLOCK_IP_PREFIXES` | | | Comma separated list of CIDRs to not resolve public domains to. |
-| `DNS_REBINDING_PROTECTION_EXEMPT_HOSTNAMES` | | Comma separated list of public domain names | Public domain names to exclude from DNS rebinding protection |
+| `DNS_REBINDING_PROTECTION_EXEMPT_HOSTNAMES` | | Comma separated list of public domain names | Public domain names to exclude from DNS rebinding protection. Parent domains such as `*.example.com` are allowed; the wildcard must appear only at the start. |
 | `DNS_UPDATE_PERIOD` | `24h` | i.e. `0`, `30s`, `5m`, `24h` | Period to update block lists and restart the DNS server. Set to `0` to deactivate updates |
 | `BLOCK_MALICIOUS` | `on` | `on`, `off` | Block malicious hostnames and IPs |
 | `BLOCK_SURVEILLANCE` | `off` | `on`, `off` | Block surveillance hostnames and IPs |

--- a/setup/options/firewall.md
+++ b/setup/options/firewall.md
@@ -13,6 +13,8 @@
 
 > **Note**: Make sure that `FIREWALL_OUTBOUND_SUBNETS` does **not** overlap with the VPN tunnel address range (for example a `10.x.x.x/` Wireguard network). If it overlaps, Gluetun may route traffic intended for the VPN (such as Proton VPN's NAT-PMP port forwarding to `10.x.x.1:5351`) via the outbound subnet instead, which breaks port forwarding and can cause `connection refused` errors. See also [gluetun#3013](https://github.com/qdm12/gluetun/issues/3013) for a real-world example.
 
+> **Note**: If you access IPs in `FIREWALL_OUTBOUND_SUBNETS` through a DNS entry that points to them, they need to be in `DNS_REBINDING_PROTECTION_EXEMPT_HOSTNAMES` as gluetun blocks dns entries pointing to private IP adresses by default (DNS rebinding protection).
+
 ## Custom iptables rules
 
 If you need to specify additional iptables rules to be run after the built-in iptables rules, you can use the file at `/iptables/post-rules.txt` with one iptables command per line and these will automatically be run on container start.

--- a/setup/options/firewall.md
+++ b/setup/options/firewall.md
@@ -13,6 +13,7 @@
 
 > **Note**: Make sure that `FIREWALL_OUTBOUND_SUBNETS` does **not** overlap with the VPN tunnel address range (for example a `10.x.x.x/` Wireguard network). If it overlaps, Gluetun may route traffic intended for the VPN (such as Proton VPN's NAT-PMP port forwarding to `10.x.x.1:5351`) via the outbound subnet instead, which breaks port forwarding and can cause `connection refused` errors. See also [gluetun#3013](https://github.com/qdm12/gluetun/issues/3013) for a real-world example.
 
+
 > **Note**: If you access IPs in `FIREWALL_OUTBOUND_SUBNETS` through a DNS entry that points to them, they need to be in `DNS_REBINDING_PROTECTION_EXEMPT_HOSTNAMES` as gluetun blocks dns entries pointing to private IP adresses by default (DNS rebinding protection).
 
 ## Custom iptables rules


### PR DESCRIPTION
Document that if you access IPs in `FIREWALL_OUTBOUND_SUBNETS` through a DNS entry that resolves to them, the hostname must be added to `DNS_REBINDING_PROTECTION_EXEMPT_HOSTNAMES` since by default, gluetun blocks DNS records that resolve to private IP addresses (as far as i understand).

Also document that DNS_REBINDING_PROTECTION_EXEMPT_HOSTNAMES allows wildcards at the start of the domain name as implemented in qdm12/gluetun@e828ea1462a48e5d6fa79c0f9c4d4ae23c6ab52e